### PR TITLE
Fix/env resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2026-03-31
+
+### Fixed
+
+- CLI commands failed to locate `.env` when installed from PyPI (`pip install xtrace-ai-sdk`). `dotenv.load_dotenv()` without arguments searches from the caller's file directory (site-packages), never reaching the user's working directory. All 13 call sites now use `find_dotenv(usecwd=True)` for cwd-based discovery. Editable installs (`pip install -e .`) were unaffected because the source tree sits under the user's home directory.
+
 ## [0.1.0] - 2026-03-30
 
 ### Initial release

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p><strong> The encrypted vector database.<br>Your data never leaves your machine in plaintext. </strong></p>
 
 <p>
-  <a href="https://pypi.org/project/xtrace-ai-sdk/"><img src="https://img.shields.io/pypi/v/xtrace-ai-sdk?color=blue&label=PyPI" alt="PyPI"></a>
+  <a href="https://pypi.org/project/xtrace-ai-sdk/"><img src="https://img.shields.io/pypi/v/xtrace-ai-sdk?color=blue&label=PyPI&cacheSeconds=0" alt="PyPI"></a>
   <a href="https://github.com/XTraceAI/xtrace-sdk/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache--2.0-ffffff?labelColor=d4eaf7&color=2e6cc4" alt="License"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/Python-3.11+-3776AB?logo=python&logoColor=white" alt="Python 3.11+"></a>
   <a href="https://docs.xtrace.ai"><img src="https://img.shields.io/badge/Docs-docs.xtrace.ai-blue" alt="Docs"></a>

--- a/src/xtrace_sdk/cli/commands/fetch.py
+++ b/src/xtrace_sdk/cli/commands/fetch.py
@@ -113,7 +113,7 @@ def fetch(
     # load environment
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv  # lazy
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         required = ["XTRACE_ORG_ID", "XTRACE_API_URL", "XTRACE_EXECUTION_CONTEXT_PATH", "XTRACE_PASS_PHRASE"]
         if api_key_override is None:
             required.append("XTRACE_API_KEY")

--- a/src/xtrace_sdk/cli/commands/head.py
+++ b/src/xtrace_sdk/cli/commands/head.py
@@ -97,7 +97,7 @@ def head(
     # load env
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         required = ["XTRACE_ORG_ID", "XTRACE_API_URL", "XTRACE_EXECUTION_CONTEXT_PATH", "XTRACE_PASS_PHRASE"]
         if api_key_override is None:
             required.append("XTRACE_API_KEY")

--- a/src/xtrace_sdk/cli/commands/init.py
+++ b/src/xtrace_sdk/cli/commands/init.py
@@ -678,7 +678,7 @@ def init(
             # load from disk (needed so embedding setup can read embed_len)
             with safe_status("Loading existing execution context…"):
                 import dotenv
-                dotenv.load_dotenv()
+                dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
                 required = ["XTRACE_PASS_PHRASE", "XTRACE_EXECUTION_CONTEXT_PATH"]
                 env_vars = _require_env(required)
                 passphrase = env_vars["XTRACE_PASS_PHRASE"]

--- a/src/xtrace_sdk/cli/commands/knowledgebase/create.py
+++ b/src/xtrace_sdk/cli/commands/knowledgebase/create.py
@@ -77,7 +77,7 @@ def create_kb(
     # load environment
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv  # lazy
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         required = ["XTRACE_ORG_ID"]
         if api_key_override is None:
             required.append("XTRACE_API_KEY")

--- a/src/xtrace_sdk/cli/commands/knowledgebase/delete.py
+++ b/src/xtrace_sdk/cli/commands/knowledgebase/delete.py
@@ -59,7 +59,7 @@ def delete_kb(
 )-> None:
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv  # lazy
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         env = _require_env(["XTRACE_ORG_ID"])
     org_id = env["XTRACE_ORG_ID"]
     api_url = (os.getenv("XTRACE_API_URL") or "https://api.production.xtrace.ai").rstrip("/")

--- a/src/xtrace_sdk/cli/commands/knowledgebase/describe.py
+++ b/src/xtrace_sdk/cli/commands/knowledgebase/describe.py
@@ -87,7 +87,7 @@ def describe_kb(
     # load environment
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv  # lazy
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         required = ["XTRACE_ORG_ID"]
         if api_key_override is None:
             required.append("XTRACE_API_KEY")

--- a/src/xtrace_sdk/cli/commands/knowledgebase/list.py
+++ b/src/xtrace_sdk/cli/commands/knowledgebase/list.py
@@ -75,7 +75,7 @@ def list_kbs(
     # load env
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv  # lazy
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         # org is always required; API key only when no override
         required = ["XTRACE_ORG_ID"]
         if api_key_override is None:

--- a/src/xtrace_sdk/cli/commands/load.py
+++ b/src/xtrace_sdk/cli/commands/load.py
@@ -145,7 +145,7 @@ def load(
     # load .env
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv  # lazy import
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         env = _require_env(
             "XTRACE_ORG_ID", "XTRACE_API_KEY", "XTRACE_API_URL",
             "XTRACE_EXECUTION_CONTEXT_PATH", "XTRACE_PASS_PHRASE", "XTRACE_EMBEDDING_MODEL_PATH"

--- a/src/xtrace_sdk/cli/commands/retrieve.py
+++ b/src/xtrace_sdk/cli/commands/retrieve.py
@@ -131,7 +131,7 @@ def retrieve(
     # load environment
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         required = ["XTRACE_ORG_ID", "XTRACE_API_URL", "XTRACE_EXECUTION_CONTEXT_PATH", "XTRACE_PASS_PHRASE", "XTRACE_EMBEDDING_MODEL_PATH"]
         if api_key_override is None:
             required.append("XTRACE_API_KEY")

--- a/src/xtrace_sdk/cli/commands/upsert.py
+++ b/src/xtrace_sdk/cli/commands/upsert.py
@@ -70,7 +70,7 @@ def upsert(
 
     with safe_status("Loading environment…"):
         import dotenv 
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         env = _require_env([
             "XTRACE_ORG_ID",
             "XTRACE_API_KEY",

--- a/src/xtrace_sdk/cli/commands/upsert_file.py
+++ b/src/xtrace_sdk/cli/commands/upsert_file.py
@@ -65,7 +65,7 @@ def upsert_file(
     # env
     with safe_status("Loading environment…"):
         import dotenv 
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         env = _require_env([
             "XTRACE_ORG_ID",
             "XTRACE_API_KEY",

--- a/src/xtrace_sdk/cli/shell.py
+++ b/src/xtrace_sdk/cli/shell.py
@@ -168,7 +168,7 @@ def run_shell() -> int:
 
         # Create one persistent XTraceIntegration for the whole shell session
         import dotenv
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         _org_id  = os.getenv("XTRACE_ORG_ID")
         _api_key = os.getenv("XTRACE_API_KEY")
         _api_url = (os.getenv("XTRACE_API_URL") or "https://api.production.xtrace.ai").rstrip("/")

--- a/src/xtrace_sdk/cli/state.py
+++ b/src/xtrace_sdk/cli/state.py
@@ -119,7 +119,7 @@ def load_once(console: Console | None = None) -> None:
     
     try:
         import dotenv
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
     except Exception:
         pass
 


### PR DESCRIPTION
CLI commands failed to locate `.env` when installed from PyPI (`pip install xtrace-ai-sdk`). `dotenv.load_dotenv()` without arguments searches from the caller's file directory (site-packages), never reaching the user's working directory. All 13 call sites now use `find_dotenv(usecwd=True)` for cwd-based discovery. Editable installs (`pip install -e .`) were unaffected because the source tree sits under the user's home directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all CLI entrypoints locate `.env`, which can affect configuration loading across every command (especially when run from non-standard directories). Logic is straightforward but could surface edge cases where callers relied on previous search behavior.
> 
> **Overview**
> **Fixes `.env` discovery for PyPI-installed CLI commands** by switching all CLI `dotenv.load_dotenv()` call sites to load via `dotenv.find_dotenv(usecwd=True)`, ensuring lookup starts from the user’s current working directory rather than `site-packages`.
> 
> Also updates the README PyPI badge to disable caching and adds a `0.1.1` changelog entry describing the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7ce6023ed7b37fd055874285ee4961aaed50c79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->