### PR TITLE
Fix/env resolution (#6)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,10 @@ jobs:
 
       - name: Resolve version from git tag
         run: |
-          VER=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          echo "SETUPTOOLS_SCM_PRETEND_VERSION=${VER#v}" >> "$GITHUB_ENV"
+          if git describe --tags --exact-match HEAD 2>/dev/null; then
+            VER=$(git describe --tags --exact-match HEAD)
+            echo "SETUPTOOLS_SCM_PRETEND_VERSION=${VER#v}" >> "$GITHUB_ENV"
+          fi
 
       - name: Build artifacts
         run: uv build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2026-03-31
+
+### Fixed
+
+- CLI commands failed to locate `.env` when installed from PyPI (`pip install xtrace-ai-sdk`). `dotenv.load_dotenv()` without arguments searches from the caller's file directory (site-packages), never reaching the user's working directory. All 13 call sites now use `find_dotenv(usecwd=True)` for cwd-based discovery. Editable installs (`pip install -e .`) were unaffected because the source tree sits under the user's home directory.
+
 ## [0.1.0] - 2026-03-30
 
 ### Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - CLI commands failed to locate `.env` when installed from PyPI (`pip install xtrace-ai-sdk`). `dotenv.load_dotenv()` without arguments searches from the caller's file directory (site-packages), never reaching the user's working directory. All 13 call sites now use `find_dotenv(usecwd=True)` for cwd-based discovery. Editable installs (`pip install -e .`) were unaffected because the source tree sits under the user's home directory.
+- `_chunk_into_pages` emitted oversized chunks when a single sentence exceeded `page_size`. These are now hard-split by character boundary. `_chunk_json` gains a `cap_json_elements` option to further split array elements that exceed the page size.
+- `init` no longer warns about `.env` key conflicts when the existing value already matches the value being written. T
+
+### Added
+
+- `EmbeddingError` exception in `x_vec.inference.embedding` with `status` and `chunk_len` fields. The Ollama provider now parses error responses instead of raising a bare `aiohttp` `ClientResponseError`.
+- `load` and `upsert-file` accept `--max-chunk-chars` to cap chunk size (splits oversized chunks via the text chunker) and `--max-parallel-embeddings` to limit concurrent embedding requests.
+- All CLI commands that embed (`load`, `upsert`, `upsert-file`, `retrieve`) catch `EmbeddingError` and print context-specific hints (e.g. suggesting `--max-chunk-chars` for context-length errors, `--max-parallel-embeddings` for server-busy errors).
 
 ## [0.1.0] - 2026-03-30
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p><strong> The encrypted vector database.<br>Your data never leaves your machine in plaintext. </strong></p>
 
 <p>
-  <a href="https://pypi.org/project/xtrace-ai-sdk/"><img src="https://img.shields.io/pypi/v/xtrace-ai-sdk?color=blue&label=PyPI" alt="PyPI"></a>
+  <a href="https://pypi.org/project/xtrace-ai-sdk/"><img src="https://img.shields.io/pypi/v/xtrace-ai-sdk?color=blue&label=PyPI&cacheSeconds=0" alt="PyPI"></a>
   <a href="https://github.com/XTraceAI/xtrace-sdk/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache--2.0-ffffff?labelColor=d4eaf7&color=2e6cc4" alt="License"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/Python-3.11+-3776AB?logo=python&logoColor=white" alt="Python 3.11+"></a>
   <a href="https://docs.xtrace.ai"><img src="https://img.shields.io/badge/Docs-docs.xtrace.ai-blue" alt="Docs"></a>

--- a/docs/manual_rst/cli_commands.rst
+++ b/docs/manual_rst/cli_commands.rst
@@ -96,9 +96,13 @@ x-vec commands — ``xtrace xvec``
 
 .. code-block:: bash
 
-    xtrace xvec load {/path/to/dir/} {KB_ID} [-f {file-types,...}] [--help]
+    xtrace xvec load {/path/to/dir/} {KB_ID} [-f {file-types,...}] [--max-chunk-chars {N}] [--max-parallel-embeddings {N}] [--help]
 
 Loads data from a directory into a knowledge base with id ``KB_ID``, processing files of type ``.txt``, ``.md``, ``.json``, and ``.csv``. To filter by file type, use ``-f`` with a comma-separated list (e.g. ``txt,json``).
+
+``--max-chunk-chars {N}`` sets a character limit per chunk. Chunks that exceed this limit (e.g. large JSON array elements) are split to fit. Useful when your embedding model has a small context window.
+
+``--max-parallel-embeddings {N}`` limits the number of concurrent embedding requests. Useful when your embedding provider has concurrency limits (e.g. a local Ollama instance).
 
 ``retrieve``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -150,9 +154,11 @@ Inserts a single text chunk into a knowledge base. Wrap ``text`` in quotes if it
 
 .. code-block:: bash
 
-    xtrace xvec upsert-file {/path/to/file} {KB_ID} [--help]
+    xtrace xvec upsert-file {/path/to/file} {KB_ID} [--max-chunk-chars {N}] [--max-parallel-embeddings {N}] [--help]
 
 Inserts and chunks the contents of a single file into a knowledge base. Supported types: ``.txt``, ``.md``, ``.json``, ``.csv``. For multiple files, use ``load``.
+
+``--max-chunk-chars {N}`` and ``--max-parallel-embeddings {N}`` behave the same as in ``load`` (see above).
 
 x-mem commands — ``xtrace xmem``
 --------------------------------------------------

--- a/src/xtrace_sdk/cli/commands/_utils/_disk_loader.py
+++ b/src/xtrace_sdk/cli/commands/_utils/_disk_loader.py
@@ -33,6 +33,8 @@ class LocalDiskConnector:
         file_path: str,
         page_size: int = PAGE_SIZE,
         page_overlap: int = PAGE_OVERLAP,
+        *,
+        cap_json_elements: bool = False,
     ) -> list[str]:
         p = Path(file_path)
         ext = p.suffix.lower()
@@ -45,7 +47,7 @@ class LocalDiskConnector:
         if ext in (".txt", ".md"):
             return _chunk_into_pages(text, page_size, page_overlap)
         elif ext == ".json":
-            return _chunk_json(text, page_size, page_overlap)
+            return _chunk_json(text, page_size, page_overlap, cap_elements=cap_json_elements)
         elif ext == ".csv":
             return _chunk_csv(text, page_size, page_overlap)
         return [text.strip()]
@@ -74,13 +76,14 @@ def _chunk_into_pages(text: str, page_size: int, overlap: int) -> list[str]:
     for sentence in sentences:
         s_len = len(sentence)
 
-        # Single sentence bigger than a page — give it its own chunk
+        # Single sentence bigger than a page — hard-split by characters
         if s_len > page_size:
             if current:
                 pages.append(" ".join(current))
                 current = []
                 current_len = 0
-            pages.append(sentence)
+            for i in range(0, s_len, page_size):
+                pages.append(sentence[i:i + page_size])
             continue
 
         if current_len + s_len + 1 > page_size and current:
@@ -110,8 +113,12 @@ def _chunk_into_pages(text: str, page_size: int, overlap: int) -> list[str]:
     return [p for p in pages if p.strip()]
 
 
-def _chunk_json(text: str, page_size: int, overlap: int) -> list[str]:
-    """JSON arrays: each element is a chunk. Non-arrays: chunk as text."""
+def _chunk_json(text: str, page_size: int, overlap: int, *, cap_elements: bool = False) -> list[str]:
+    """JSON arrays: each element is a chunk. Non-arrays: chunk as text.
+
+    When *cap_elements* is True, array elements larger than *page_size* are
+    further split via _chunk_into_pages (triggered by --max-chunk-chars).
+    """
     try:
         data = json.loads(text)
     except json.JSONDecodeError:
@@ -128,7 +135,11 @@ def _chunk_json(text: str, page_size: int, overlap: int) -> list[str]:
             chunk = item
         else:
             chunk = str(item)
-        if chunk.strip():
+        if not chunk.strip():
+            continue
+        if cap_elements and len(chunk) > page_size:
+            chunks.extend(_chunk_into_pages(chunk, page_size, overlap))
+        else:
             chunks.append(chunk)
     return chunks if chunks else [text.strip()]
 

--- a/src/xtrace_sdk/cli/commands/fetch.py
+++ b/src/xtrace_sdk/cli/commands/fetch.py
@@ -113,7 +113,7 @@ def fetch(
     # load environment
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv  # lazy
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         required = ["XTRACE_ORG_ID", "XTRACE_API_URL", "XTRACE_EXECUTION_CONTEXT_PATH", "XTRACE_PASS_PHRASE"]
         if api_key_override is None:
             required.append("XTRACE_API_KEY")

--- a/src/xtrace_sdk/cli/commands/head.py
+++ b/src/xtrace_sdk/cli/commands/head.py
@@ -97,7 +97,7 @@ def head(
     # load env
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         required = ["XTRACE_ORG_ID", "XTRACE_API_URL", "XTRACE_EXECUTION_CONTEXT_PATH", "XTRACE_PASS_PHRASE"]
         if api_key_override is None:
             required.append("XTRACE_API_KEY")

--- a/src/xtrace_sdk/cli/commands/init.py
+++ b/src/xtrace_sdk/cli/commands/init.py
@@ -678,7 +678,7 @@ def init(
             # load from disk (needed so embedding setup can read embed_len)
             with safe_status("Loading existing execution context…"):
                 import dotenv
-                dotenv.load_dotenv()
+                dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
                 required = ["XTRACE_PASS_PHRASE", "XTRACE_EXECUTION_CONTEXT_PATH"]
                 env_vars = _require_env(required)
                 passphrase = env_vars["XTRACE_PASS_PHRASE"]

--- a/src/xtrace_sdk/cli/commands/init.py
+++ b/src/xtrace_sdk/cli/commands/init.py
@@ -535,7 +535,9 @@ def _append_env_keys(
 
     for k, v in updates.items():
         if k in active_keys and not overwrite_active:
-            skipped.append(k)
+            # only report a conflict when the existing value actually differs
+            if active_keys[k] != v:
+                skipped.append(k)
         elif k in all_keys and k not in active_keys:
             # key exists only as a comment — also skip to avoid confusion
             skipped.append(k)

--- a/src/xtrace_sdk/cli/commands/knowledgebase/create.py
+++ b/src/xtrace_sdk/cli/commands/knowledgebase/create.py
@@ -77,7 +77,7 @@ def create_kb(
     # load environment
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv  # lazy
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         required = ["XTRACE_ORG_ID"]
         if api_key_override is None:
             required.append("XTRACE_API_KEY")

--- a/src/xtrace_sdk/cli/commands/knowledgebase/delete.py
+++ b/src/xtrace_sdk/cli/commands/knowledgebase/delete.py
@@ -59,7 +59,7 @@ def delete_kb(
 )-> None:
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv  # lazy
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         env = _require_env(["XTRACE_ORG_ID"])
     org_id = env["XTRACE_ORG_ID"]
     api_url = (os.getenv("XTRACE_API_URL") or "https://api.production.xtrace.ai").rstrip("/")

--- a/src/xtrace_sdk/cli/commands/knowledgebase/describe.py
+++ b/src/xtrace_sdk/cli/commands/knowledgebase/describe.py
@@ -87,7 +87,7 @@ def describe_kb(
     # load environment
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv  # lazy
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         required = ["XTRACE_ORG_ID"]
         if api_key_override is None:
             required.append("XTRACE_API_KEY")

--- a/src/xtrace_sdk/cli/commands/knowledgebase/list.py
+++ b/src/xtrace_sdk/cli/commands/knowledgebase/list.py
@@ -75,7 +75,7 @@ def list_kbs(
     # load env
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv  # lazy
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         # org is always required; API key only when no override
         required = ["XTRACE_ORG_ID"]
         if api_key_override is None:

--- a/src/xtrace_sdk/cli/commands/load.py
+++ b/src/xtrace_sdk/cli/commands/load.py
@@ -145,7 +145,7 @@ def load(
     # load .env
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv  # lazy import
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         env = _require_env(
             "XTRACE_ORG_ID", "XTRACE_API_KEY", "XTRACE_API_URL",
             "XTRACE_EXECUTION_CONTEXT_PATH", "XTRACE_PASS_PHRASE", "XTRACE_EMBEDDING_MODEL_PATH"

--- a/src/xtrace_sdk/cli/commands/load.py
+++ b/src/xtrace_sdk/cli/commands/load.py
@@ -11,6 +11,7 @@ from rich.rule import Rule
 from contextlib import contextmanager
 import warnings
 from ._utils._errors import extract_server_error
+from xtrace_sdk.x_vec.inference.embedding import EmbeddingError
 
 from xtrace_sdk.cli.state import get_pre, get_exec_context, get_embed_model, get_integration
 
@@ -99,7 +100,12 @@ def _iter_matching_files(root: Path, types: Set[str] | None) -> Iterable[Path]:
             if ext in types:
                 yield p
 
-def _collect_from_folder(folder: str, types: Set[str] | None) -> Tuple[List[Dict[str, Any]], int]:
+def _collect_from_folder(
+    folder: str,
+    types: Set[str] | None,
+    *,
+    max_chunk_chars: int | None = None,
+) -> Tuple[List[Dict[str, Any]], int]:
     """
     Walk folder, load only matching files via LocalDiskConnector.load_data_from_file,
     convert to chunks with required meta_data. Returns (chunks, matched_file_count).
@@ -110,12 +116,17 @@ def _collect_from_folder(folder: str, types: Set[str] | None) -> Tuple[List[Dict
     if not root.is_dir():
         raise typer.BadParameter(f"Folder not found or not a directory: {folder}")
 
+    load_kwargs: Dict[str, Any] = {}
+    if max_chunk_chars is not None:
+        load_kwargs["page_size"] = max_chunk_chars
+        load_kwargs["cap_json_elements"] = True
+
     collection: List[Dict[str, Any]] = []
     matched_files = 0
 
     for path in _iter_matching_files(root, types):
         try:
-            docs = LocalDiskConnector.load_data_from_file(str(path))
+            docs = LocalDiskConnector.load_data_from_file(str(path), **load_kwargs)
         except ValueError:
             # unsupported type or unreadable file — skip silently since we filtered by ext
             continue
@@ -141,6 +152,17 @@ def load(
              "Types are matched to file extensions (no dot), case-insensitive."
     ),
     json_out: bool = typer.Option(False, "--json", help="Output JSON summary"),
+    max_chunk_chars: int | None = typer.Option(
+        None, "--max-chunk-chars",
+        help="Maximum characters per chunk. Oversized chunks (e.g. large JSON objects) "
+             "are split to fit within this limit. Useful when your embedding model has a "
+             "small context window.",
+    ),
+    max_parallel_embeddings: int | None = typer.Option(
+        None, "--max-parallel-embeddings",
+        help="Maximum number of concurrent embedding requests. "
+             "Useful when your embedding provider has concurrency limits (e.g. local Ollama).",
+    ),
 ) -> None:
     # load .env
     with _maybe_status("Loading environment…", enable=not json_out):
@@ -207,7 +229,7 @@ def load(
     try:
         # scan and chunk local files (filtered)
         with _maybe_status("Scanning files and preparing chunks…", enable=not json_out):
-            collection, matched_files = _collect_from_folder(folder_path, types)
+            collection, matched_files = _collect_from_folder(folder_path, types, max_chunk_chars=max_chunk_chars)
 
         if matched_files == 0:
             if json_out:
@@ -215,7 +237,10 @@ def load(
             elif types:
                 console.print(f"[yellow]No files matched the provided types ({', '.join(sorted(types))}).[/]")
             else:
-                console.print("[yellow]No readable files found.[/]")
+                from xtrace_sdk.cli.commands._utils._disk_loader import _SUPPORTED
+                supported = ", ".join(sorted(_SUPPORTED))
+                console.print(f"[yellow]No readable files found. Supported types: {supported}[/]")
+            console.print("[dim]Hint: for advanced ingestion workflows, use the Python SDK directly.[/]")
             raise typer.Exit(1)
 
         n_chunks = len(collection)
@@ -235,21 +260,51 @@ def load(
             embedding_model = obj.get("embedding") if isinstance(obj, dict) else obj
 
         async def _embed_all() -> list[Any]:
+            if max_parallel_embeddings is not None:
+                sem = asyncio.Semaphore(max_parallel_embeddings)
+                async def _limited(text: str) -> Any:
+                    async with sem:
+                        return await embedding_model.bin_embed(text)
+                return list(await asyncio.gather(*[
+                    _limited(c["chunk_content"]) for c in collection
+                ]))
             return list(await asyncio.gather(*[
                 embedding_model.bin_embed(c["chunk_content"]) for c in collection
             ]))
-        try:
-            vectors = asyncio.run(_embed_all())
-        except Exception as e:
-            msg, code = extract_server_error(e)
-            if json_out:
-                _json_error(msg or str(e), code, kb_id=kb_id)
-            elif msg:
-                status = f" ({code})" if code is not None else ""
-                console.print(f"[red]Embedding failed{status}:[/] {msg}")
-            else:
-                console.print(f"[red]Embedding failed:[/] {e}")
-            raise typer.Exit(1)
+        with _maybe_status("Embedding chunks…", enable=not json_out):
+            try:
+                vectors = asyncio.run(_embed_all())
+            except EmbeddingError as e:
+                status = f" ({e.status})" if e.status is not None else ""
+                detail = f" (chunk was {e.chunk_len:,} chars)" if e.chunk_len else ""
+                if json_out:
+                    _json_error(str(e), e.status, kb_id=kb_id)
+                else:
+                    console.print(f"[red]Embedding failed{status}:[/] {e}{detail}")
+                    err_lower = str(e).lower()
+                    if e.chunk_len and "context length" in err_lower:
+                        console.print(
+                            "[yellow]Hint:[/] some chunks exceed your embedding model's context window. "
+                            "Re-run with [bold]--max-chunk-chars N[/] to split large chunks "
+                            "(e.g. [dim]--max-chunk-chars 3000[/])."
+                        )
+                    elif "server busy" in err_lower or "pending requests" in err_lower:
+                        console.print(
+                            "[yellow]Hint:[/] too many concurrent embedding requests. "
+                            "Re-run with [bold]--max-parallel-embeddings N[/] to limit concurrency "
+                            "(e.g. [dim]--max-parallel-embeddings 5[/])."
+                        )
+                raise typer.Exit(1)
+            except Exception as e:
+                msg, code = extract_server_error(e)
+                if json_out:
+                    _json_error(msg or str(e), code, kb_id=kb_id)
+                elif msg:
+                    status = f" ({code})" if code is not None else ""
+                    console.print(f"[red]Embedding failed{status}:[/] {msg}")
+                else:
+                    console.print(f"[red]Embedding failed:[/] {e}")
+                raise typer.Exit(1)
 
         index, db = asyncio.run(dl.load_data_from_memory(collection, vectors))  # type: ignore[arg-type]
         if not json_out:
@@ -279,6 +334,7 @@ def load(
             }, ensure_ascii=False))
         else:
             console.print(f"[bold green]Loaded {n_chunks} chunk(s)[/] → KB [bold blue]{kb_id}[/]")
+            console.print("[dim]Note: the CLI uses basic chunking. For custom chunking strategies, use the Python SDK.[/]")
     finally:
         if _owned:
             try:

--- a/src/xtrace_sdk/cli/commands/retrieve.py
+++ b/src/xtrace_sdk/cli/commands/retrieve.py
@@ -131,7 +131,7 @@ def retrieve(
     # load environment
     with _maybe_status("Loading environment…", enable=not json_out):
         import dotenv
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         required = ["XTRACE_ORG_ID", "XTRACE_API_URL", "XTRACE_EXECUTION_CONTEXT_PATH", "XTRACE_PASS_PHRASE", "XTRACE_EMBEDDING_MODEL_PATH"]
         if api_key_override is None:
             required.append("XTRACE_API_KEY")

--- a/src/xtrace_sdk/cli/commands/retrieve.py
+++ b/src/xtrace_sdk/cli/commands/retrieve.py
@@ -12,6 +12,7 @@ from rich.rule import Rule
 from rich.table import Table
 from contextlib import contextmanager, nullcontext, redirect_stdout, redirect_stderr
 from ._utils._errors import extract_server_error
+from xtrace_sdk.x_vec.inference.embedding import EmbeddingError
 from typing import cast
 from typing import NoReturn
 from typing import Any, Iterator
@@ -227,6 +228,24 @@ def retrieve(
                 return await retriever.nn_search_for_ids(bits, k, kb_id=kb_id)
             ids = asyncio.run(_search())
             ids = _to_py_int_list(ids)
+        except EmbeddingError as e:
+            status = f" ({e.status})" if e.status is not None else ""
+            detail = f" (query was {e.chunk_len:,} chars)" if e.chunk_len else ""
+            if json_out:
+                _json_error(str(e), e.status)
+            else:
+                console.print(f"[red]Embedding failed{status}:[/] {e}{detail}")
+                err_lower = str(e).lower()
+                if e.chunk_len and "context length" in err_lower:
+                    console.print(
+                        "[yellow]Hint:[/] the query exceeds your embedding model's context window. "
+                        "Try shortening the query."
+                    )
+                elif "server busy" in err_lower or "pending requests" in err_lower:
+                    console.print(
+                        "[yellow]Hint:[/] embedding server is overloaded. Try again shortly."
+                    )
+            raise typer.Exit(1)
         except Exception as e:
             msg, code = extract_server_error(e)
             if json_out:

--- a/src/xtrace_sdk/cli/commands/upsert.py
+++ b/src/xtrace_sdk/cli/commands/upsert.py
@@ -70,7 +70,7 @@ def upsert(
 
     with safe_status("Loading environment…"):
         import dotenv 
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         env = _require_env([
             "XTRACE_ORG_ID",
             "XTRACE_API_KEY",

--- a/src/xtrace_sdk/cli/commands/upsert.py
+++ b/src/xtrace_sdk/cli/commands/upsert.py
@@ -7,7 +7,8 @@ from typing import Dict, Any
 from rich.console import Console
 from rich.rule import Rule
 from contextlib import contextmanager
-from ._utils._errors import extract_server_error 
+from ._utils._errors import extract_server_error
+from xtrace_sdk.x_vec.inference.embedding import EmbeddingError
 from collections.abc import Generator
 
 from xtrace_sdk.cli.state import get_pre, get_exec_context, get_embed_model, get_integration
@@ -153,6 +154,21 @@ def upsert(
                     vectors,
                     disable_progress=True
                 ))
+            except EmbeddingError as e:
+                status = f" ({e.status})" if e.status is not None else ""
+                detail = f" (chunk was {e.chunk_len:,} chars)" if e.chunk_len else ""
+                console.print(f"[red]Embedding failed{status}:[/] {e}{detail}")
+                err_lower = str(e).lower()
+                if e.chunk_len and "context length" in err_lower:
+                    console.print(
+                        "[yellow]Hint:[/] the text exceeds your embedding model's context window. "
+                        "Try shortening the input."
+                    )
+                elif "server busy" in err_lower or "pending requests" in err_lower:
+                    console.print(
+                        "[yellow]Hint:[/] embedding server is overloaded. Try again shortly."
+                    )
+                raise typer.Exit(1)
             except Exception as e:
                 msg, code = extract_server_error(e)
                 console.print(
@@ -169,6 +185,7 @@ def upsert(
                 raise typer.Exit(1)
 
         console.print(f"[bold green]Upserted 1 chunk[/] → KB [bold blue]{kb_id}[/].")
+        console.print("[dim]Note: the CLI uses basic chunking. For custom chunking strategies, use the Python SDK.[/]")
     finally:
         if _owned:
             try:

--- a/src/xtrace_sdk/cli/commands/upsert_file.py
+++ b/src/xtrace_sdk/cli/commands/upsert_file.py
@@ -8,7 +8,8 @@ from typing import Dict, Any, Iterable, Iterator
 from rich.console import Console
 from rich.rule import Rule
 from contextlib import contextmanager
-from ._utils._errors import extract_server_error 
+from ._utils._errors import extract_server_error
+from xtrace_sdk.x_vec.inference.embedding import EmbeddingError
 
 from xtrace_sdk.cli.state import get_pre, get_exec_context, get_embed_model, get_integration
 
@@ -59,6 +60,17 @@ def _silence_transformers_future_warning()-> None:
 def upsert_file(
     file_path: str = typer.Argument(..., help="Path to a single file"),
     kb_id: str    = typer.Argument(..., help="Knowledge Base ID"),
+    max_chunk_chars: int | None = typer.Option(
+        None, "--max-chunk-chars",
+        help="Maximum characters per chunk. Oversized chunks (e.g. large JSON objects) "
+             "are split to fit within this limit. Useful when your embedding model has a "
+             "small context window.",
+    ),
+    max_parallel_embeddings: int | None = typer.Option(
+        None, "--max-parallel-embeddings",
+        help="Maximum number of concurrent embedding requests. "
+             "Useful when your embedding provider has concurrency limits (e.g. local Ollama).",
+    ),
 ) -> None:
     _silence_transformers_future_warning()
 
@@ -130,7 +142,11 @@ def upsert_file(
 
     try:
         # Load file and build collection
-        docs = LocalDiskConnector.load_data_from_file(str(p))  # may raise ValueError for unsupported types
+        load_kwargs: dict[str, Any] = {}
+        if max_chunk_chars is not None:
+            load_kwargs["page_size"] = max_chunk_chars
+            load_kwargs["cap_json_elements"] = True
+        docs = LocalDiskConnector.load_data_from_file(str(p), **load_kwargs)  # may raise ValueError for unsupported types
         collection = _to_chunk_collection(docs)
 
         # Reuse in-session execution context if available; otherwise fall back to disk
@@ -163,11 +179,37 @@ def upsert_file(
                     embedding_model = obj.get("embedding") if isinstance(obj, dict) else obj
 
                 async def _embed_all() -> list[Any]:
+                    if max_parallel_embeddings is not None:
+                        sem = asyncio.Semaphore(max_parallel_embeddings)
+                        async def _limited(text: str) -> Any:
+                            async with sem:
+                                return await embedding_model.bin_embed(text)
+                        return list(await asyncio.gather(*[
+                            _limited(c["chunk_content"]) for c in collection
+                        ]))
                     return list(await asyncio.gather(*[
                         embedding_model.bin_embed(c["chunk_content"]) for c in collection
                     ]))
                 vectors = asyncio.run(_embed_all())
                 index, db = asyncio.run(dl.load_data_from_memory(collection, vectors, disable_progress=True))  # type: ignore[arg-type]
+            except EmbeddingError as e:
+                status = f" ({e.status})" if e.status is not None else ""
+                detail = f" (chunk was {e.chunk_len:,} chars)" if e.chunk_len else ""
+                console.print(f"[red]Embedding failed{status}:[/] {e}{detail}")
+                err_lower = str(e).lower()
+                if e.chunk_len and "context length" in err_lower:
+                    console.print(
+                        "[yellow]Hint:[/] some chunks exceed your embedding model's context window. "
+                        "Re-run with [bold]--max-chunk-chars N[/] to split large chunks "
+                        "(e.g. [dim]--max-chunk-chars 3000[/])."
+                    )
+                elif "server busy" in err_lower or "pending requests" in err_lower:
+                    console.print(
+                        "[yellow]Hint:[/] too many concurrent embedding requests. "
+                        "Re-run with [bold]--max-parallel-embeddings N[/] to limit concurrency "
+                        "(e.g. [dim]--max-parallel-embeddings 5[/])."
+                    )
+                raise typer.Exit(1)
             except Exception as e:
                 msg, code = extract_server_error(e)
                 console.print(f"[red]Encryption failed{f' ({code})' if code is not None else ''}:[/] {msg or e}")
@@ -182,6 +224,7 @@ def upsert_file(
                 raise typer.Exit(1)
 
         console.print(f"[bold green]Upserted {len(collection)} chunk(s)[/] → KB [bold blue]{kb_id}[/].")
+        console.print("[dim]Note: the CLI uses basic chunking. For custom chunking strategies, use the Python SDK.[/]")
     finally:
         if _owned:
             try:

--- a/src/xtrace_sdk/cli/commands/upsert_file.py
+++ b/src/xtrace_sdk/cli/commands/upsert_file.py
@@ -65,7 +65,7 @@ def upsert_file(
     # env
     with safe_status("Loading environment…"):
         import dotenv 
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         env = _require_env([
             "XTRACE_ORG_ID",
             "XTRACE_API_KEY",

--- a/src/xtrace_sdk/cli/shell.py
+++ b/src/xtrace_sdk/cli/shell.py
@@ -168,7 +168,7 @@ def run_shell() -> int:
 
         # Create one persistent XTraceIntegration for the whole shell session
         import dotenv
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
         _org_id  = os.getenv("XTRACE_ORG_ID")
         _api_key = os.getenv("XTRACE_API_KEY")
         _api_url = (os.getenv("XTRACE_API_URL") or "https://api.production.xtrace.ai").rstrip("/")

--- a/src/xtrace_sdk/cli/state.py
+++ b/src/xtrace_sdk/cli/state.py
@@ -119,7 +119,7 @@ def load_once(console: Console | None = None) -> None:
     
     try:
         import dotenv
-        dotenv.load_dotenv()
+        dotenv.load_dotenv(dotenv.find_dotenv(usecwd=True))
     except Exception:
         pass
 

--- a/src/xtrace_sdk/x_vec/inference/embedding.py
+++ b/src/xtrace_sdk/x_vec/inference/embedding.py
@@ -1,3 +1,4 @@
+import json
 import os
 import ssl
 from typing import Any
@@ -5,6 +6,15 @@ from typing import Any
 import aiohttp
 import certifi
 import numpy as np
+
+
+class EmbeddingError(Exception):
+    """Raised when the embedding provider returns an error."""
+
+    def __init__(self, message: str, *, status: int | None = None, chunk_len: int | None = None):
+        self.status = status
+        self.chunk_len = chunk_len
+        super().__init__(message)
 
 
 class Embedding:
@@ -69,7 +79,13 @@ class Embedding:
                 raise RuntimeError("URL not configured for ollama provider")
             async with aiohttp.ClientSession() as session, \
                     session.post(self.url, json={"model": self.model_name, "prompt": text}, ssl=ssl_ctx) as resp:
-                resp.raise_for_status()
+                if resp.status != 200:
+                    body = await resp.text()
+                    try:
+                        error_msg = json.loads(body).get("error", body)
+                    except Exception:
+                        error_msg = body
+                    raise EmbeddingError(error_msg, status=resp.status, chunk_len=len(text))
                 data = await resp.json()
                 float_embd = np.asarray(data.get("embedding", []))
 


### PR DESCRIPTION
* Update pip version badge (#5)

* use cwd based dotenv instead of caller-file based

* update change log

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple CLI entrypoints and chunking/embedding error handling; behavior changes could affect ingestion/query results and concurrency under load, but scope is limited to CLI and embedding provider error surfaces.
> 
> **Overview**
> Fixes CLI `.env` discovery when installed from PyPI by switching all `dotenv.load_dotenv()` call sites to `find_dotenv(usecwd=True)`.
> 
> Improves ingestion robustness: text chunking now hard-splits single overlong sentences, JSON chunking can optionally cap/split oversized array elements, and `xtrace xvec load`/`upsert-file` add `--max-chunk-chars` plus `--max-parallel-embeddings` to control chunk size and embedding concurrency.
> 
> Adds `EmbeddingError` (with HTTP `status` and `chunk_len`) and updates the Ollama embedding provider plus embedding CLI commands (`load`, `upsert`, `upsert-file`, `retrieve`) to catch it and print targeted hints; also tightens `init` env conflict warnings and adjusts release workflow versioning to only set `SETUPTOOLS_SCM_PRETEND_VERSION` on exact tag builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb96aa1f79a92d6b6f0c1f6389d3daadff5546be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->